### PR TITLE
Hotfix ds to key topics

### DIFF
--- a/content/key_topics/airquality.md
+++ b/content/key_topics/airquality.md
@@ -4,6 +4,7 @@ date: 2021-04-14T12:32:15-04:00
 draft: false
 tags: 
 categories: [airquality]
+relatedCategory: airquality
 keywords: 
 ---
 

--- a/content/key_topics/childhealth.md
+++ b/content/key_topics/childhealth.md
@@ -3,7 +3,8 @@ title: "Child Health"
 date: 2021-05-05T07:59:26-04:00
 draft: false
 tags: 
-categories: [childhealth]
+categories: ["childhealth"]
+relatedCategory: childhealth
 keywords: 
 ---
 

--- a/content/key_topics/climatehealth.md
+++ b/content/key_topics/climatehealth.md
@@ -4,6 +4,7 @@ date: 2021-04-14T12:33:17-04:00
 draft: false
 tags: 
 categories: [climatehealth]
+relatedCategory: climatehealth
 keywords: 
 ---
 

--- a/content/key_topics/foodanddrink.md
+++ b/content/key_topics/foodanddrink.md
@@ -4,6 +4,7 @@ date: 2021-05-05T07:58:53-04:00
 draft: false
 tags: 
 categories: [foodanddrink]
+relatedCategory: foodanddrink
 keywords: 
 ---
 

--- a/content/key_topics/housing.md
+++ b/content/key_topics/housing.md
@@ -4,6 +4,7 @@ date: 2021-05-05T07:56:00-04:00
 draft: false
 tags: 
 categories: [housing]
+relatedCategory: housing
 keywords: 
 ---
 Most people spend most of their time at home - so the household environment can significantly affect health. Disrepair that stems from longterm maintenance neglect can lead to serious health problems, including: lead poisoning from lead paint; asthma and other respiratory issues triggered by pests; and carbon monoxide poisoning.

--- a/content/key_topics/pests.md
+++ b/content/key_topics/pests.md
@@ -4,6 +4,7 @@ date: 2021-05-05T07:59:02-04:00
 draft: false
 tags: 
 categories: [pests]
+relatedCategory: pests
 keywords: 
 ---
 

--- a/content/key_topics/social.md
+++ b/content/key_topics/social.md
@@ -4,6 +4,7 @@ date: 2021-05-05T07:59:16-04:00
 draft: false
 tags: 
 categories: [social]
+relatedCategory: social
 keywords: 
 ---
 

--- a/content/key_topics/transportation.md
+++ b/content/key_topics/transportation.md
@@ -4,6 +4,7 @@ date: 2021-05-05T07:58:01-04:00
 draft: false
 tags: 
 categories: [transportation]
+relatedCategory: transportation
 keywords: 
 ---
 

--- a/formats.md
+++ b/formats.md
@@ -37,14 +37,18 @@ This code works on any template page to range through items in another content s
 {{end}}
 ```
 
-It can be elaborated on with additional conditions. This should nest an if loop, looking for data_stories where a "categories" parameter equals "airquality." 
+It can be elaborated on with additional conditions. This looks for data_stories that have a category that intersects with the key topic's relatedCategory.
 
 ```
-{{ range where .Site.Pages "Section" "data_stories" }}
-    {{ if eq "categories" "airquality"}}
-        {{ .Title }}<br>
-    {{ end}}
-{{end}}
+            {{ range where ( where .Site.RegularPages "Section" "data_stories") ".Params.categories" "intersect" ( slice .Params.relatedCategory ) }}
+            <h3>Related Data Stories</h3>
+            <ul>
+                    <li><a href="{{ .URL}}">{{ .Title }}</a></li>
+            </ul>
+            {{ end}}  
 ```
 
-When we sub in "airquality" for a variable that matches the specific key topic, we can display matching Data Stories on a specific Key Topic page just by publishing a new Data Story with a cateogory that matches the Key Topic.
+For this to work, key topics need the following format in the frontmattr:
+```
+    relatedCategory: airquality
+```

--- a/themes/dohmh/layouts/key_topics/single.html
+++ b/themes/dohmh/layouts/key_topics/single.html
@@ -28,14 +28,17 @@
             {{ .Content}}
     
     
-            <h3>Data Stories</h3>
-            <p>Ranging through data stories:</p>
+
+
             <hr>
+
+            {{ range where ( where .Site.RegularPages "Section" "data_stories") ".Params.categories" "intersect" ( slice .Params.relatedCategory ) }}
+            <h3>Related Data Stories</h3>
             <ul>
-            {{ range where .Site.RegularPages "Section" "data_stories" }}
                     <li><a href="{{ .URL}}">{{ .Title }}</a></li>
-            {{ end}}    
             </ul>
+            {{ end}}    
+
     
         </div>
 


### PR DESCRIPTION
@grantpezeshki - this includes Key Topic template code that ingests related data stories. It relies on data stories' front matter including categories where the categories match the key topics - e.g.: ```categories: ["airquality","childhealth","social"]```

And, it relies on a key topic's markdown having relatedCategory, formatted as: ```relatedCategory: airquality```

Adam is looking into whether there's a way to use intersect to just match based on categories instead of having to have Key Topics include relatedCategory in the frontmatter, but if not - this is functional and will work for our needs!

We should be able to use a similar approach for ingesting related data stories into subtopics, too.