### PR TITLE
added environment to header.html for banner image

### DIFF
--- a/themes/dohmh/layouts/partials/header.html
+++ b/themes/dohmh/layouts/partials/header.html
@@ -55,7 +55,7 @@
 
     </div>
     <!-- #nyc-top-header -->
-    <div class="site-header bg-primary">
+    <div class="site-header bg-primary" style="background-image: url({{ $.Site.Params.devpath}}/images/header_background.jpg)">
         <div class="wrap-header">
 
             <div class="container-fluid wide">


### PR DESCRIPTION
@grantpezeshki - you were right that Hugo only parses Hugo code in HTML, not in CSS or JS files. So, in header.html, I added the reference to the banner image using the environment variable ```{{ $.Site.Params.devpath}}```. Using ```hugo serve --environment local``` properly displays the banner image.