### PR TITLE
Conditional related content ingestion

### DIFF
--- a/themes/dohmh/layouts/key_topics/single.html
+++ b/themes/dohmh/layouts/key_topics/single.html
@@ -29,8 +29,8 @@
             </div>
 
             <div class="row mt-2">
+                <!--Conditional if code only executes contents (related partial) if that intersection content exists. So it removes header if null content-->
                 {{ if where ( where .Site.RegularPages "Section" "data_stories") ".Params.categories" "intersect" ( slice .Params.relatedCategory ) }}
-
                 <div class="col-md-6 pl-0">
                     <h3><i class="fas fa-passport mr-1" aria-hidden="true"></i>Data Stories</h3>
                     <div class="card content-card mb-4">

--- a/themes/dohmh/layouts/key_topics/single.html
+++ b/themes/dohmh/layouts/key_topics/single.html
@@ -28,8 +28,9 @@
                 {{ .Content}}
             </div>
 
-
             <div class="row mt-2">
+                {{ if where ( where .Site.RegularPages "Section" "data_stories") ".Params.categories" "intersect" ( slice .Params.relatedCategory ) }}
+
                 <div class="col-md-6 pl-0">
                     <h3><i class="fas fa-passport mr-1" aria-hidden="true"></i>Data Stories</h3>
                     <div class="card content-card mb-4">
@@ -46,20 +47,22 @@
                         </div>
                     </div>
                 </div>
-
+                {{ end }}
+                <!--end conditional here-->
 
 
 
                 <div class="col-md-6 pl-0">
+                    {{ if where ( where .Site.RegularPages "Section" "neighborhood_reports") ".Params.categories" "intersect" ( slice .Params.relatedCategory ) }}
+                        <h3><i class="fas fa-map-marked-alt mr-1" aria-hidden="true"></i>Neighborhood Reports</h3>
+                        {{ partial "related" (dict "section" "neighborhood_reports" "layout" "button" "content" . ) }}
+                        <hr class="my-2">
+                    {{ end }}
 
-                    <h3><i class="fas fa-map-marked-alt mr-1" aria-hidden="true"></i>Neighborhood Reports</h3>
-                    {{ partial "related" (dict "section" "neighborhood_reports" "layout" "button" "content" . ) }}
-
-                    <hr class="my-2">
-
-                    <h3><i class="fas fa-chart-bar mr-1" aria-hidden="true"></i>Data Features</h3>
-                    {{ partial "related" (dict "section" "key_topics" "layout" "button" "content" . ) }}     
-
+                    {{ if where ( where .Site.RegularPages "Section" "key_topics") ".Params.categories" "intersect" ( slice .Params.relatedCategory ) }}
+                        <h3><i class="fas fa-chart-bar mr-1" aria-hidden="true"></i>Data Features</h3>
+                        {{ partial "related" (dict "section" "key_topics" "layout" "button" "content" . ) }}     
+                    {{ end }}
 
                 </div>
 

--- a/themes/dohmh/layouts/key_topics/single.html
+++ b/themes/dohmh/layouts/key_topics/single.html
@@ -31,19 +31,15 @@
 
             <div class="row mt-2">
                 <div class="col-md-6 pl-0">
+                    <h3><i class="fas fa-passport mr-1" aria-hidden="true"></i>Data Stories</h3>
                     <div class="card content-card mb-4">
                         <div class="card-content">
                             <div class="card-body">
-                                <h3><i class="fas fa-passport mr-1" aria-hidden="true"></i>Data Stories</h3>
                                     <p class="card-text">        
 
-                                            <!--Returns data stories if their categories intersect with this page's relatedCategory/keyTopic-->
-                                            {{ range where ( where .Site.RegularPages "Section" "data_stories") ".Params.categories" "intersect" ( slice .Params.relatedCategory ) }}
-                                           <a href="{{ .URL}}">{{ .Title }}</a>
-                                           <hr class="my-1">
+                                        {{ partial "related" (dict "section" "data_stories" "layout" "card" "content" . ) }}
 
-                                            {{ end}}   
-                                            <a style="float:right" class="my-2" href="/data_stories/">See all Data Stories.</a>
+                                            <a style="float:right" class="my-2" href="/data_stories/">See all Data Stories<span class="fas fa-angle-right ml-1" aria-hidden="true"></span></a>
 
                                     </p>
                             </div>
@@ -56,34 +52,14 @@
 
                 <div class="col-md-6 pl-0">
 
-                    <h3><i class="fas fa-chart-bar mr-1" aria-hidden="true"></i>Data features:</h3>
-                    {{ $page_link := .Permalink }}
-                    {{ $cats := .Params.categories }}
-                    {{ range where .Site.RegularPages "Section" "key_topics" }}
-                    {{ $page := . }}
-                    {{ $has_common_cats := intersect $cats .Params.categories | len | lt 0 }}
-                    {{ if and $has_common_cats (ne $page_link $page.Permalink) }}
-                    <a class="btn btn-outline-primary btn-lg has-icon disperse" href="{{ .URL}}">
-                        <span class="fas fa-angle-right"></span>
-                        <span class="title">{{ .Title }}</span>
-                    </a>
-                    {{ end }} 
-                    {{ end }}
+                    <h3><i class="fas fa-map-marked-alt mr-1" aria-hidden="true"></i>Neighborhood Reports</h3>
+                    {{ partial "related" (dict "section" "neighborhood_reports" "layout" "button" "content" . ) }}
 
+                    <hr class="my-2">
 
-                    <h3 class="mt-4"><i class="fas fa-map-marked-alt mr-1" aria-hidden="true"></i>Neighborhood Reports</h3>
-                    {{ $page_link := .Permalink }}
-                    {{ $cats := .Params.categories }}
-                    {{ range where .Site.RegularPages "Section" "neighborhood_reports" }}
-                    {{ $page := . }}
-                    {{ $has_common_cats := intersect $cats .Params.categories | len | lt 0 }}
-                    {{ if and $has_common_cats (ne $page_link $page.Permalink) }}
-                    <a class="btn btn-outline-primary btn-lg has-icon disperse" href="{{ .URL}}">
-                        <span class="fas fa-angle-right"></span>
-                        <span class="title">{{ .Title }}</span>
-                    </a>
-                    {{ end }} 
-                    {{ end }}
+                    <h3><i class="fas fa-chart-bar mr-1" aria-hidden="true"></i>Data Features</h3>
+                    {{ partial "related" (dict "section" "key_topics" "layout" "button" "content" . ) }}     
+
 
                 </div>
 
@@ -100,20 +76,11 @@
             <div class="row mt-4 mb-4">
 
                     <h3><i class="fas fa-chart-line pr-1" aria-hidden="true"></i>Get the data: <span class="text-muted">Related datasets in the Data Explorer</span></h3>
-                    <p class="card-text">        
-                        <ul>
-                            {{ $page_link := .Permalink }}
-                            {{ $cats := .Params.categories }}
-                            {{ range where .Site.RegularPages "Section" "data_explorer" }}
-                            {{ $page := . }}
-                            {{ $has_common_cats := intersect $cats .Params.categories | len | lt 0 }}
-                            {{ if and $has_common_cats (ne $page_link $page.Permalink) }}
-                            <li><a href="{{ .URL}}">{{ .Title }}</a></li>
-                            {{ end }} 
-                            {{ end }}
 
-                        </ul></p>
-
+                    <hr>
+                    {{ partial "related" (dict "section" "data_explorer" "layout" "list" "content" . ) }}
+                   
+                    
 
             </div>
 

--- a/themes/dohmh/layouts/partials/related.html
+++ b/themes/dohmh/layouts/partials/related.html
@@ -1,13 +1,32 @@
-<h4>{{ .header }} </h4>
-{{ $page_link := .Permalink }}
-{{ $cats := .Params.categories }}
-{{ range where .Site.RegularPages "Section" "{{ .area }}" }}
-{{ $page := . }}
-{{ $has_common_cats := intersect $cats .Params.categories | len | lt 0 }}
-{{ if and $has_common_cats (ne $page_link $page.Permalink) }}
-<a class="btn btn-outline-primary btn-lg has-icon disperse" href="{{ .URL}}">
-    <span class="fas fa-angle-right"></span>
-    <span class="title">{{ .Title }}</span>
-</a>
-{{ end }} 
+
+{{ $page_link := $.content.Permalink }}
+{{ $cats := $.content.Params.categories }}
+{{ $layout := .layout }}
+
+{{ range where $.content.Site.RegularPages "Section" .section }}
+    {{ $page := . }}
+    {{ $has_common_cats := intersect $cats .Params.categories | len | lt 0 }}
+        {{ if and $has_common_cats (ne $page_link $page.Permalink) }}
+
+            {{ if eq $layout "button"}}
+
+            <a class="btn btn-outline-primary btn-lg has-icon disperse mb-1" href="{{ .URL}}">
+            <span class="fas fa-angle-right" aria-hidden="true"></span>
+            <span class="title">{{ .Title }}</span>
+            </a>
+
+            {{ else if eq $layout "card"}}
+            <a href="{{ .URL}}">{{ .Title }}</a>
+            <hr class="my-1">
+
+            {{ else if eq $layout "list"}}
+            <div class="col-md-6 pl-0">
+                <p><a href="{{ .URL}}">{{ .Title}}</a></p>
+            </div>
+
+
+            {{ end }}
+
+        {{ end}}
+
 {{ end }}


### PR DESCRIPTION
Hey @grantpezeshki - a nice little bit of functionality in the template at ```key_topics/single.html```

To pull in related data stories, neighborhood reports, and 'data features' (like the interactive HVI for example) to a Key Topic page, we call a partial, ```related.html```, and give it some parameters. Within that partial, there are some ```if:else``` code - this lets us call the partial from the template but say whether we want the returned content to display as a card, buttons, or list:

```{{ partial "related" (dict "section" "data_stories" "layout" "card" "content" . ) }}```

The problem with this is that if this related content partial returns no results (there is no related content), then there's still the header - "Data Stories" or others - that would appear.

So, in the template, I added an if statement that looks for content, and only executes the nested code if it returns true:

![image](https://user-images.githubusercontent.com/55593359/134206945-5d27a452-d6da-4e10-9dc2-d6aeafdd475a.png)

As a result, our Air Quality KT page, for example, shows all of its related content:
![image](https://user-images.githubusercontent.com/55593359/134209201-a1704128-e837-4c84-8468-ee4d772d5021.png)

but our humble P&P KT page, with no related content, shows only its related datasets:
![image](https://user-images.githubusercontent.com/55593359/134209158-a3ad03e3-2413-427b-9312-47240dd32609.png)

