### PR TITLE
Add conditional for chart partial - so it only appears on NR pages

### DIFF
--- a/assets/scss/theme.scss
+++ b/assets/scss/theme.scss
@@ -529,7 +529,7 @@ h2.report-info {
 
 }
 
-.better {
+.worse {
     background-color: #F2CDD7;
 }
 
@@ -537,7 +537,7 @@ h2.report-info {
     background-color: #F2EDDD;
 }
 
-.worse {
+.better {
     background-color: #D1F0C8;
 }
 .comparison {

--- a/themes/dohmh/layouts/partials/head.html
+++ b/themes/dohmh/layouts/partials/head.html
@@ -9,7 +9,10 @@
   {{ if .Params.seo_title }}{{ .Params.seo_title }}{{ else }}{{ .Title }}{{ end }} &#x7c; {{ .Site.Title }}
 {{ end }}</title>
 {{ partial "seo" . }}
-{{ partial "chart" . }}
+
+{{ if eq .Page.Section "neighborhood_reports"}}
+  {{ partial "chart" . }}
+{{ end }}
 
 <!-- jQuery (full, compressed version) -->
 <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>


### PR DESCRIPTION
the partial chart.html includes some JS for neighborhood reports chart specs. Accordingly, it should only be ingested into head.html for neighborhood reports pages. Added simple code to ensure this. 

Also revised css for these chart-adjacent NR better/worse flags to have proper colors. 