### PR TITLE
Update topo.json ref in HVI

### DIFF
--- a/content/key_topics/climatehealth/hvi/HVIMapSpec.vg.json
+++ b/content/key_topics/climatehealth/hvi/HVIMapSpec.vg.json
@@ -9,7 +9,7 @@
       {"name": "source_1", "url": "../../../visualizations/csv/hvi/hvi-nta.csv", "format": {"type": "csv"}},
       {
         "name": "source_0",
-        "url": "https://raw.githubusercontent.com/nycehs/AQHub_prototype/master/data/NTA2.topo.json",
+        "url": "https://raw.githubusercontent.com/nycehs/NYC_geography/master/NTA.topo.json",
         "format": {"type": "topojson", "feature": "collection"},
         "transform": [{"type": "identifier", "as": "_vgsid_"}]
       },


### PR DESCRIPTION
Broken link to an old NTA topo.json file in the HVI interactive. Fixed. 