### PR TITLE
add exit modal for indicator links

### DIFF
--- a/themes/dohmh/layouts/data_explorer/single.html
+++ b/themes/dohmh/layouts/data_explorer/single.html
@@ -23,7 +23,7 @@
             <div class="col-md-4">
                 <h4 class="greenfill"><i class="fas fa-chart-line mr-1" aria-hidden="true"></i>Get data:</h4>
                 {{ range .Params.indicators}}
-                    <a href="{{.URL}}" onclick="protoPopup()">{{.name}}</a>
+                    <a href="#" onclick="protoPopup({{ .URL}})">{{.name}}</a>
                     <hr>
                 {{end}}
 
@@ -100,12 +100,43 @@
 </article>
 
 
+<!--Script powers exit modal-->
 <script>
-    function protoPopup() {
-        alert("This link is taking you to a dataset displayed on the old version of the EH Data Portal. To continue to the data, click OK. To return to the prototype, just hit the back button.");
+    var destination;
+
+    function protoPopup(URL) {
+        destination = URL;
+        $('#prototypeModal').modal('show')
+        document.getElementById('modalDestination').setAttribute("href", destination)
     }
 
 </script>
+
+<!-- Exit modal-->
+<div class="modal" tabindex="-1" role="dialog" id="prototypeModal">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">You're leaving the prototype.</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <p>This link is taking you to a dataset displayed on the old version of the EH Data Portal.</p> 
+          <p>If you want to return to this prototype, just hit the back button in your web browser.</p>
+        </div>
+        <div class="modal-footer">
+            <button type="button" class="btn btn-secondary-outline float-left" data-dismiss="modal">Go Back</button>
+
+            <a href="" id="modalDestination">
+            <button  type="button" class="btn btn-secondary float-right">Get the data <i class="far fa-arrow-alt-circle-right ml-1"></i></button></a>
+
+
+        </div>
+      </div>
+    </div>
+  </div>
 
 
 {{end}}


### PR DESCRIPTION
Adding an exit modal for indicator links, to tell somebody that the indicator is taking them to the "old" portal.